### PR TITLE
[NumericTicTacToe] Optimize move selection logic

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,37 @@
 
 This document provides guidelines for GitHub Copilot when working on C# projects. These instructions help maintain consistency with established codebase standards, conventions, and architectural patterns.
 
+## General Instructions for Copilot Responses
+
+- Provide concise, focused explanations without unnecessary elaboration.
+- When analyzing images, first describe exactly what is visually present before conducting any web-based research.
+- Cross-check all details with both the image and external sources to ensure accuracy.
+- Clearly explain your reasoning by verifying claims step by step.
+- Avoid hallucinations at all costs—only respond with grounded, verifiable information.
+
 ## Code Standards & Conventions
+
+### .NET Performance and Memory Allocation Guidelines
+
+**CRITICAL: Never dismiss allocation concerns as "negligible" or assume garbage collection is "effortless."**
+
+Modern .NET performance best practices emphasize **allocation reduction** as a primary optimization strategy:
+
+- **Gen0 collections have real costs** - CPU overhead and pause times that accumulate
+- **Allocation rate often matters more than allocation size** - frequent small allocations can be more problematic than occasional large ones
+- **Use allocation-reducing patterns** when appropriate:
+  - `Span<T>` and `Memory<T>` for temporary data
+  - `ArrayPool<T>` for reusable buffers
+  - `stackalloc` for small, short-lived arrays
+  - Avoid unnecessary LINQ chains that create intermediate collections
+
+**When evaluating allocation trade-offs:**
+- Consider the allocation frequency and context
+- Measure actual performance impact when in doubt
+- Acknowledge that allocation reduction is a legitimate optimization concern
+- Balance allocation concerns with code maintainability appropriately
+
+**Never suggest that garbage collection "handles allocations effortlessly" - this contradicts fundamental .NET
 
 ### C# Language Features
 

--- a/src/NumericTicTacToe/.github/copilot-instructions.md
+++ b/src/NumericTicTacToe/.github/copilot-instructions.md
@@ -6,7 +6,37 @@ This document provides guidelines for GitHub Copilot when working on the Numeric
 
 Numeric Tic-Tac-Toe is a strategic variant of classic Tic-Tac-Toe that uses numbers instead of X's and O's. Players use odd (1,3,5,7,9) or even (2,4,6,8) numbers and win by creating lines that sum to exactly 15. The project demonstrates clean architecture principles with extensible rendering and player implementations.
 
+## General Instructions for Copilot Responses
+
+- Provide concise, focused explanations without unnecessary elaboration.
+- When analyzing images, first describe exactly what is visually present before conducting any web-based research.
+- Cross-check all details with both the image and external sources to ensure accuracy.
+- Clearly explain your reasoning by verifying claims step by step.
+- Avoid hallucinations at all costs—only respond with grounded, verifiable information.
+
 ## Code Standards & Conventions
+
+### .NET Performance and Memory Allocation Guidelines
+
+**CRITICAL: Never dismiss allocation concerns as "negligible" or assume garbage collection is "effortless."**
+
+Modern .NET performance best practices emphasize **allocation reduction** as a primary optimization strategy:
+
+- **Gen0 collections have real costs** - CPU overhead and pause times that accumulate
+- **Allocation rate often matters more than allocation size** - frequent small allocations can be more problematic than occasional large ones
+- **Use allocation-reducing patterns** when appropriate:
+  - `Span<T>` and `Memory<T>` for temporary data
+  - `ArrayPool<T>` for reusable buffers
+  - `stackalloc` for small, short-lived arrays
+  - Avoid unnecessary LINQ chains that create intermediate collections
+
+**When evaluating allocation trade-offs:**
+- Consider the allocation frequency and context
+- Measure actual performance impact when in doubt
+- Acknowledge that allocation reduction is a legitimate optimization concern
+- Balance allocation concerns with code maintainability appropriately
+
+**Never suggest that garbage collection "handles allocations effortlessly" - this contradicts fundamental .NET
 
 ### C# Language Features
 - **Target Framework**: .NET 9.0
@@ -155,6 +185,10 @@ public async Task<Move> PlayTurnAsync(GameState gameState,
 ```
 
 ## Testing Standards
+
+### General Test Guidlines
+- You do not have to ask to execute tests, so long as the command being used is `dotnet test`.
+- When writing or updating tests, DO NOT make changes to the implementation.  If the behavior being tested is incorrect, provide your analysis in chat clearly and succinctly for human analysis and review.
 
 ### Test Organization
 - **Test Namespace**: All test classes must use `Squire.NumTic.Tests` namespace (never area-specific namespaces like `NumTic.Tests.Game`)

--- a/src/NumericTicTacToe/src/Game/Players/BotPlayer.cs
+++ b/src/NumericTicTacToe/src/Game/Players/BotPlayer.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Collections.Concurrent;
-using System.Diagnostics;
-using System.Reflection;
 using Squire.NumTic.Contracts;
 
 namespace Squire.NumTic.Players;
@@ -157,6 +154,8 @@ public class BotPlayer : IPlayer
         }
 
         var board = gameState.Board;
+        var baseScore = Math.Max(1000, maxLookAhead * 100);
+
         var firstMove = default(Move?);
         var scoredMoves = new ConcurrentDictionary<Move, int>();
         var tasks = new List<Task<int>>();
@@ -179,7 +178,7 @@ public class BotPlayer : IPlayer
                         {
                             var (currentState, currentIndex, currentToken) = ((GameState, int, byte))state!;
                             var move = new Move(currentState.CurrentTurn, currentIndex, currentToken);
-                            return ScoreMove(move, currentState, currentState.CurrentTurn, currentDepth + 1, maxLookAhead, int.MinValue, int.MaxValue, scoredMoves, cancellationToken);
+                            return ScoreMove(move, currentState, currentState.CurrentTurn, currentDepth + 1, maxLookAhead, int.MinValue, int.MaxValue, baseScore, scoredMoves, cancellationToken);
 
                         }, (gameState.CreateCopy(), index, token), cancellationToken);
 
@@ -204,6 +203,7 @@ public class BotPlayer : IPlayer
                 maxLookAhead,
                 int.MinValue,
                 int.MaxValue,
+                baseScore,
                 scoredMoves,
                 cancellationToken)));
 
@@ -212,10 +212,11 @@ public class BotPlayer : IPlayer
         _ = await Task.WhenAll(tasks).ConfigureAwait(false);
 
         return scoredMoves
-            .GroupBy(scoredMove => scoredMove.Value)
-            .OrderByDescending(group => group.Key)
+            .Where(scoredMove => scoredMove.Key.Player == gameState.CurrentTurn)
+            .GroupBy(static scoredMove => scoredMove.Value)
+            .OrderByDescending(static group => group.Key)
             .First()
-            .OrderBy(_ => Random.Shared.Next())
+            .OrderBy(static _ => Random.Shared.Next())
             .First()
             .Key;
     }
@@ -232,6 +233,7 @@ public class BotPlayer : IPlayer
     /// <param name="maxDepth">The maximum recursive depth allowed when evaluating future moves.</param>
     /// <param name="currentBestScoreForDesiredPlayer">The best score guaranteed for the desired player so far in the current search path.</param>
     /// <param name="currentWorstScoreForOpponent">The worst score the opponent will tolerate before choosing a different path.</param>
+    /// <param name="baseScore">The number to use as the basis for scoring before win/lose adjustments are applied.</param>
     /// <param name="scoredMoves">The set of moves that have been scored. This set will be mutated by this call.</param>
     /// <param name="cancellationToken">A token that can be used to signal a request for cancellation.</param>
     ///
@@ -257,6 +259,7 @@ public class BotPlayer : IPlayer
                                  int maxDepth,
                                  int currentBestScoreForDesiredPlayer,
                                  int currentWorstScoreForOpponent,
+                                 int baseScore,
                                  ConcurrentDictionary<Move, int> scoredMoves,
                                  CancellationToken cancellationToken)
     {
@@ -293,7 +296,14 @@ public class BotPlayer : IPlayer
 
             if (winningNext is not null)
             {
-                var score = winningNext.Value.Player == desiredWinner ? 1 : -1;
+                // A winning move for the desired player is more appealing the earlier it can
+                // be made.  Likewise, the earlier an opponent wins, the more important it is
+                // to avoid that branch.  Adjust the score based on the current depth in the
+                // search tree to capture that.
+
+                var score = winningNext.Value.Player == desiredWinner
+                    ? baseScore + (maxDepth - currentDepth)
+                    : -(baseScore - (maxDepth - currentDepth));
 
                 _ = scoredMoves.TryAdd(move, score);
                 return score;
@@ -311,16 +321,28 @@ public class BotPlayer : IPlayer
 
             cancellationToken.ThrowIfCancellationRequested();
 
+            // Because the game state is mutable, a copy of the current player's tokens must be made
+            // to avoid the loop iteration being impacted by state changes made by the recursive calls
+            // when evaluating moves.
+
+            var playerTokens = (Span<byte>)stackalloc byte[gameState.CurrentPlayerTokens.Count];
+            var index = 0;
+
+            foreach (var token in gameState.CurrentPlayerTokens)
+            {
+                playerTokens[index++] = token;
+            }
+
             // Evaluate the possible follow-up moves from this position.
 
             var board = gameState.Board;
             var shouldContinueSearching = true;
 
-            for (var index = 0; index < board.Length; ++index)
+            for (index = 0; index < board.Length; ++index)
             {
                 if (board[index] == GameState.EmptyBoardSpaceValue)
                 {
-                    foreach (var token in gameState.CurrentPlayerTokens)
+                    foreach (var token in playerTokens)
                     {
                         var nextMove = new Move(gameState.CurrentTurn, index, token);
 
@@ -332,6 +354,7 @@ public class BotPlayer : IPlayer
                             maxDepth,
                             currentBestScoreForDesiredPlayer,
                             currentWorstScoreForOpponent,
+                            baseScore,
                             scoredMoves,
                             cancellationToken);
 

--- a/src/NumericTicTacToe/tests/Players/BotPlayerTests.cs
+++ b/src/NumericTicTacToe/tests/Players/BotPlayerTests.cs
@@ -371,6 +371,132 @@ public class BotPlayerTests
     }
 
     /// <summary>
+    ///   Verifies that the bot prefers immediate wins over delayed wins.
+    /// </summary>
+    ///
+    [Test]
+    public async Task BotPrefersImmediateWinsOverDelayedWins()
+    {
+        var mockGameInterface = Substitute.For<IGameInterface>();
+        var botPlayer = new BotPlayer(mockGameInterface, new BotPlayerOptions { Difficulty = Difficulty.Hard });
+        var gameState = CreateStateWithImmediateWinOption();
+
+        var move = await botPlayer.PlayTurnAsync(gameState);
+
+        // The bot should choose the immediate win (token 9 at position 2) over any delayed win sequence.
+
+        Assert.That(move.Token, Is.EqualTo(9), "Should choose immediate winning token");
+        Assert.That(move.PositionIndex, Is.EqualTo(2), "Should choose immediate winning position");
+
+        // Verify it's actually the immediate winning move.
+
+        var testState = gameState.CreateCopy();
+        testState.ApplyMove(move);
+
+        Assert.That(testState.Winner, Is.EqualTo(PlayerToken.Odd), "Move should result in immediate win");
+    }
+
+    /// <summary>
+    ///   Verifies that the bot prefers delayed losses when all moves lead to opponent wins.
+    /// </summary>
+    ///
+    [Test]
+    public async Task BotPrefersDelayedLossesWhenAllMovesLose()
+    {
+        var mockGameInterface = Substitute.For<IGameInterface>();
+        var botPlayer = new BotPlayer(mockGameInterface, new BotPlayerOptions { Difficulty = Difficulty.Hard });
+        var gameState = CreateStateWhereAllMovesLeadToLoss();
+
+        var move = await botPlayer.PlayTurnAsync(gameState);
+
+        // Verify the bot makes a valid move that delays the opponent's win.
+
+        Assert.That(move.Player, Is.EqualTo(gameState.CurrentTurn), "Should make move for current player");
+        Assert.That(gameState.GetPlayerTokens(gameState.CurrentTurn), Contains.Item(move.Token), "Should use available token");
+        Assert.That(gameState.Board[move.PositionIndex], Is.EqualTo(GameState.EmptyBoardSpaceValue), "Should place on empty space");
+
+        // The specific move choice will depend on the implementation, but it should be a valid delaying move.
+    }
+
+    /// <summary>
+    ///   Verifies that depth-based scoring calculates correct values for wins and losses.
+    /// </summary>
+    ///
+    [Test]
+    public async Task DepthBasedScoringCalculatesCorrectValues()
+    {
+        var mockGameInterface = Substitute.For<IGameInterface>();
+        var botPlayer = new BotPlayer(mockGameInterface, new BotPlayerOptions { Difficulty = Difficulty.Medium });
+        var gameState = CreateValidGameState();
+
+        // The base score calculation should follow the formula: Math.Max(1000, maxDepth * 100).
+        // For medium difficulty with our game state, maxDepth should be around 3.
+        // Base score should be Math.Max(1000, 3 * 100) = 1000.
+
+        var move = await botPlayer.PlayTurnAsync(gameState);
+
+        // Verify the bot makes a reasonable move (specific score testing requires internal access).
+
+        Assert.That(move.Player, Is.EqualTo(gameState.CurrentTurn), "Should make move for current player");
+        Assert.That(gameState.GetPlayerTokens(gameState.CurrentTurn), Contains.Item(move.Token), "Should use available token");
+        Assert.That(gameState.Board[move.PositionIndex], Is.EqualTo(GameState.EmptyBoardSpaceValue), "Should place on empty space");
+    }
+
+    /// <summary>
+    ///   Verifies that the bot distinguishes between multiple win options at different depths.
+    /// </summary>
+    ///
+    [Test]
+    public async Task BotDistinguishesBetweenWinOptionsAtDifferentDepths()
+    {
+        var mockGameInterface = Substitute.For<IGameInterface>();
+        var botPlayer = new BotPlayer(mockGameInterface, new BotPlayerOptions { Difficulty = Difficulty.Hard });
+        var gameState = CreateStateWithMultipleWinDepths();
+
+        var move = await botPlayer.PlayTurnAsync(gameState);
+
+        // When multiple winning paths exist, bot should prefer the shortest path.
+        // In our test state, there should be an immediate win available.
+
+        Assert.That(move.Player, Is.EqualTo(gameState.CurrentTurn), "Should make move for current player");
+        Assert.That(gameState.GetPlayerTokens(gameState.CurrentTurn), Contains.Item(move.Token), "Should use available token");
+        Assert.That(gameState.Board[move.PositionIndex], Is.EqualTo(GameState.EmptyBoardSpaceValue), "Should place on empty space");
+
+        // Verify it results in a win.
+
+        var testState = gameState.CreateCopy();
+        testState.ApplyMove(move);
+
+        Assert.That(testState.Winner, Is.EqualTo(gameState.CurrentTurn), "Should achieve win");
+    }
+
+    /// <summary>
+    ///   Verifies that the bot handles boundary conditions correctly at maximum depth.
+    /// </summary>
+    ///
+    [Test]
+    public async Task BotHandlesBoundaryConditionsAtMaximumDepth()
+    {
+        var mockGameInterface = Substitute.For<IGameInterface>();
+        var botPlayer = new BotPlayer(mockGameInterface, new BotPlayerOptions { Difficulty = Difficulty.Easy }, maxLookAhead: 1);
+        var gameState = CreateNearWinState();
+
+        var move = await botPlayer.PlayTurnAsync(gameState);
+
+        // Even with minimal depth, bot should find the immediate winning move.
+
+        Assert.That(move.Token, Is.EqualTo(9), "Should find winning token even at depth 1");
+        Assert.That(move.PositionIndex, Is.EqualTo(2), "Should find winning position even at depth 1");
+
+        // Verify it's the winning move.
+
+        var testState = gameState.CreateCopy();
+        testState.ApplyMove(move);
+
+        Assert.That(testState.Winner, Is.EqualTo(PlayerToken.Odd), "Should win even with limited depth");
+    }
+
+    /// <summary>
     ///   Creates a valid initial game state for testing.
     /// </summary>
     ///
@@ -486,6 +612,74 @@ public class BotPlayerTests
         gameState.ApplyMove(new Move(PlayerToken.Odd, 0, 1));   // Odd plays 1 at position 0
         gameState.ApplyMove(new Move(PlayerToken.Even, 4, 2));  // Even plays 2 at center
         gameState.ApplyMove(new Move(PlayerToken.Odd, 8, 3));   // Odd plays 3 at position 8
+
+        return gameState;
+    }
+
+    /// <summary>
+    ///   Creates a game state where the bot has an immediate win option available.
+    /// </summary>
+    ///
+    private static GameState CreateStateWithImmediateWinOption()
+    {
+        var gameState = CreateValidGameState();
+
+        // Set up the same near-win scenario as CreateNearWinState.
+        // This gives the bot an immediate win option with token 9 at position 2.
+
+        gameState.ApplyMove(new Move(PlayerToken.Odd, 0, 1));   // Odd plays 1 at position 0
+        gameState.ApplyMove(new Move(PlayerToken.Even, 3, 2));  // Even plays 2 at position 3
+        gameState.ApplyMove(new Move(PlayerToken.Odd, 1, 5));   // Odd plays 5 at position 1
+        gameState.ApplyMove(new Move(PlayerToken.Even, 4, 4));  // Even plays 4 at position 4
+
+        // Now Odd can win immediately with 9 at position 2 (1+5+9=15).
+
+        return gameState;
+    }
+
+    /// <summary>
+    ///   Creates a game state where all available moves lead to opponent wins, testing loss delay preference.
+    /// </summary>
+    ///
+    private static GameState CreateStateWhereAllMovesLeadToLoss()
+    {
+        var gameState = CreateValidGameState();
+
+        // Create a scenario where Even is threatening and Odd must choose between bad options.
+        // This tests the bot's ability to prefer delayed losses over immediate ones.
+
+        gameState.ApplyMove(new Move(PlayerToken.Odd, 0, 1));   // Odd plays 1 at position 0
+        gameState.ApplyMove(new Move(PlayerToken.Even, 1, 2));  // Even plays 2 at position 1
+        gameState.ApplyMove(new Move(PlayerToken.Odd, 2, 3));   // Odd plays 3 at position 2
+        gameState.ApplyMove(new Move(PlayerToken.Even, 4, 4));  // Even plays 4 at position 4
+
+        // Current state creates a scenario where Even has potential winning threats.
+
+        return gameState;
+    }
+
+    /// <summary>
+    ///   Creates a game state with multiple winning paths at different depths.
+    /// </summary>
+    ///
+    private static GameState CreateStateWithMultipleWinDepths()
+    {
+        var gameState = CreateValidGameState();
+
+        // Create a scenario where Odd can win immediately.
+        // Set up: 1+5 in anti-diagonal (positions 6, 4), need 9 at position 2.
+
+        gameState.ApplyMove(new Move(PlayerToken.Odd, 6, 1));   // Odd plays 1 at position 6 (bottom-left)
+        gameState.ApplyMove(new Move(PlayerToken.Even, 0, 2));  // Even plays 2 at position 0
+        gameState.ApplyMove(new Move(PlayerToken.Odd, 4, 5));   // Odd plays 5 at position 4 (center)
+        gameState.ApplyMove(new Move(PlayerToken.Even, 1, 4));  // Even plays 4 at position 1
+
+        // Board layout (3x3):
+        // [2, 4, _]  <- positions 0, 1, 2
+        // [_, 5, _]  <- positions 3, 4, 5
+        // [1, _, _]  <- positions 6, 7, 8
+        //
+        // Odd can win immediately by playing 9 at position 2 for anti-diagonal: 1+5+9=15.
 
         return gameState;
     }


### PR DESCRIPTION
The focus of these changes is to optimize the move selection logic for the algorithmic  `BotPlayer`.
Previously, move scoring used a static base that
was not adjusted for the depth in the search, leading to overvaluation of moves that resulted in wins
later in the game.  This has been adjusted to prefer wins earlier in the game and, likewise, to prefer
avoiding moves which allows the opponent to win
earlier in the game.

A couple of impactful bug fixes were also made:

  - Move selection did not filter to the current player, causing random selection of an opponent move when the best outcome was a tie.

  - A race condition with the recursive move scoring that could result in an error for concurent modification of the player's token set in the game state.